### PR TITLE
Fix Command Registration Issue for "AVR Utils: Create New Project"

### DIFF
--- a/.vscode/avr_project.json
+++ b/.vscode/avr_project.json
@@ -1,0 +1,1 @@
+{"avrDevice":null}

--- a/extension.js
+++ b/extension.js
@@ -14,17 +14,14 @@ const { dataObject } = require("./src/utils");
  * @param {vscode.ExtensionContext} context
  */
 function activate(context) {
-    console.log("Checking for data.json")
+    console.log("Checking for data.json");
     dataObject(); // To initialize the data.json file
-    console.log("Registering commands")
-    registerCommands();
-    // DO NOT MOVE THESE LINES ABOVE. THEY MUST COME FIRST
-    console.log("Initializing other dependencies")
+    console.log("Registering commands");
+    registerCommands(context); // Pass context here
+    console.log("Initializing other dependencies");
     init(context);
-
-    console.log("Registering providers")
+    console.log("Registering providers");
     registerProviders(context);
-
     console.log('"avr-utils" is now active!');
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "avr-utils",
-    "version": "0.1.6",
+    "version": "0.1.7",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "avr-utils",
-            "version": "0.1.6",
+            "version": "0.1.7",
             "license": "MIT",
             "dependencies": {
                 "decompress": "^4.2.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "onCommand:avr-utils.openMicrochipStudioProject",
         "onCommand:avr-utils.uploadToMicrocontroller"
     ],
-    "main": "./extension.js",
+    "main": "./out/main.js",
     "contributes": {
         "commands": [
             {

--- a/src/registerCommands.js
+++ b/src/registerCommands.js
@@ -5,10 +5,13 @@ const makeProject = require('./commands/makeProject');
 const openMicrochipStudioProject = require('./commands/openMicrochipStudioProject');
 const { uploadToMicrocontroller } = require('./commands/uploadToMicrocontroller');
 
-module.exports = function () {
-    vscode.commands.registerCommand('avr-utils.compileProject', compileProject);
-    vscode.commands.registerCommand('avr-utils.getToolchain', getToolchain);
-    vscode.commands.registerCommand('avr-utils.makeProject', makeProject);
-    vscode.commands.registerCommand('avr-utils.openMicrochipStudioProject', openMicrochipStudioProject);
-    vscode.commands.registerCommand('avr-utils.uploadToMicrocontroller', uploadToMicrocontroller);
-}
+module.exports = function (context) {
+    console.log('Registering AVR Utils commands');
+    context.subscriptions.push(
+        vscode.commands.registerCommand('avr-utils.compileProject', compileProject),
+        vscode.commands.registerCommand('avr-utils.getToolchain', getToolchain),
+        vscode.commands.registerCommand('avr-utils.makeProject', makeProject),
+        vscode.commands.registerCommand('avr-utils.openMicrochipStudioProject', openMicrochipStudioProject),
+        vscode.commands.registerCommand('avr-utils.uploadToMicrocontroller', uploadToMicrocontroller)
+    );
+};


### PR DESCRIPTION
This pull request resolves a command registration problem encountered after installing the extension.

### Problem
When I installed the extension in VS Code and tried the "AVR Utils: Create New Project" command, I got an error: "Command 'AVR Utils: Create New Project' resulted in an error (command 'avr-utils.makeProject' not found)". The command wasn’t registering correctly when installed, though it worked fine in local debug mode (`F5`).

### Changes
- Updated `package.json` `main` to `"./out/main.js"` to match the `esbuild` output.
- Modified `extension.js` to pass `context` to `registerCommands`.
- Revised `src/registerCommands.js` to use `context.subscriptions` for proper command registration.

### Purpose
Ensures commands like `avr-utils.makeProject` work when the extension is installed, not just in debug mode.

### Testing
I tested locally with the `.vsix` file to confirm "AVR Utils: Create New Project" works without errors.

Please review and let me know if any changes are needed!

**Update**: The update to version 0.1.7 has been released and applied in VS Code, resolving the issue. I’ve reviewed it, and in my opinion, there are no problems remaining. If you don’t see a problem, please ignore this pull request.