### PR TITLE
ci: simplify npm cache key and add version bump workflow

### DIFF
--- a/.github/workflows/build_extension.yml
+++ b/.github/workflows/build_extension.yml
@@ -27,11 +27,9 @@ jobs:
         id: npm-cache
         with:
           path: node_modules
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: ${{ runner.os }}-node-modules-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-node-modules
 
       - name: Install dependencies
-        if: steps.npm-cache.outputs.cache-hit != true
         run: npm install
       
       - name: Run build script

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -1,0 +1,59 @@
+name: Version Bump
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_type:
+        description: 'Version type to bump (patch, minor, or major)'
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: 'patch'
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.sha }}
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '18'  # Specify the Node.js version you need
+
+    - name: Install dependencies
+      run: npm install
+
+    - name: Bump version and pack
+      run: node_modules/@vscode/vsce/vsce pack ${{ github.event.inputs.version_type }}
+
+    - name: Get new version
+      id: get_version
+      run: echo "new_version=$(node -p "require('./package.json').version")" >> $GITHUB_ENV
+
+    - name: Push changes
+      run: |
+        git config --global user.name 'github-actions[bot]'
+        git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+        git add package.json package-lock.json
+        git commit -m "Bump version to ${{ env.new_version }}"
+        git push origin HEAD:bump-to-${{ env.new_version }}
+
+    - name: Create Pull Request
+      uses: peter-evans/create-pull-request@v7
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        commit-message: "Bump version to ${{ env.new_version }}"
+        title: "Bump version to ${{ env.new_version }}"
+        body: "This PR bumps the version to ${{ env.new_version }}"
+        branch: bump-to-${{ env.new_version }}
+        base: main  # Change this to your default branch if it's not 'main'
+        labels: |
+          chore


### PR DESCRIPTION
Simplify the npm cache key in the build_extension.yml workflow by removing the hashFiles dependency. Additionally, introduce a new bump-version.yml workflow to automate version bumping and PR creation for patch, minor, and major version updates.